### PR TITLE
Added support for -r/--single_reads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 #### Daily Change Log:
+* [2026.3.10] - Added `--veba_major_version` to `compile-manifest-from-veba.py` since `cluster` output directory is changing
 * [2026.3.3] - Added `step_coverage` output files [issue/#22](https://github.com/jolespin/leviathan/issues/22)
 * [2025.12.17] - Added `--table_format parquet|tsv` to `leviathan-merge.py` and merge functions in `leviathan-profile-pathway.py`/`leviathan-profile-taxonomy.py` [Issue #20](https://github.com/jolespin/leviathan/issues)
 * [2025.12.2] - Updated `xarray` concatenation to prepare for usage change in future versions [issue/#17](https://github.com/jolespin/leviathan/issues/17)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 #### Daily Change Log:
+* [2026.3.11] - Added support for `-r/--single_reads` in both `profile-taxonomy.py` and `profile-pathway.py`. However, the `profile-pathway.py` needs `oarfish` to use long reads. [issue/#24](https://github.com/jolespin/leviathan/issues/24)
 * [2026.3.10] - Added `--veba_major_version` to `compile-manifest-from-veba.py` since `cluster` output directory is changing
 * [2026.3.3] - Added `step_coverage` output files [issue/#22](https://github.com/jolespin/leviathan/issues/22)
 * [2025.12.17] - Added `--table_format parquet|tsv` to `leviathan-merge.py` and merge functions in `leviathan-profile-pathway.py`/`leviathan-profile-taxonomy.py` [Issue #20](https://github.com/jolespin/leviathan/issues)

--- a/bin/compile-manifest-from-veba.py
+++ b/bin/compile-manifest-from-veba.py
@@ -33,7 +33,7 @@ def main(args=None):
     parser_io.add_argument("-i","--veba_directory", type=str, required=True, help = "path/to/veba_directory/ (e.g., veba_output/)")
     parser_io.add_argument("-t","--organism_types", type=str, default = "prokaryotic,eukaryotic", help="Comma-separated list of organism types.  Choose between {prokaryotic, eukaryotic, viral}(e.g., prokaryotic,eukaryotic).  viral is not recommended.")
     parser_io.add_argument("-o", "--output", type=str,  default="stdout", help = "path/to/output.tsv[.gz] [Default: stdout]")
-    parser_io.add_argument("--veba_major_version", choices={2,3},  default=2, help = "Major VEBA version [Default: 2]")
+    parser_io.add_argument("--veba_major_version", type=int, choices={2,3},  default=2, help = "Major VEBA version [Default: 2]")
 
     # Options
     opts = parser.parse_args()

--- a/bin/compile-manifest-from-veba.py
+++ b/bin/compile-manifest-from-veba.py
@@ -33,6 +33,7 @@ def main(args=None):
     parser_io.add_argument("-i","--veba_directory", type=str, required=True, help = "path/to/veba_directory/ (e.g., veba_output/)")
     parser_io.add_argument("-t","--organism_types", type=str, default = "prokaryotic,eukaryotic", help="Comma-separated list of organism types.  Choose between {prokaryotic, eukaryotic, viral}(e.g., prokaryotic,eukaryotic).  viral is not recommended.")
     parser_io.add_argument("-o", "--output", type=str,  default="stdout", help = "path/to/output.tsv[.gz] [Default: stdout]")
+    parser_io.add_argument("--veba_major_version", choices={2,3},  default=2, help = "Major VEBA version [Default: 2]")
 
     # Options
     opts = parser.parse_args()
@@ -90,8 +91,11 @@ def main(args=None):
         
     # Genome clusters
     contains_genome_clusters = False
-    genome_cluster_filepath = os.path.join(opts.veba_directory, "cluster", "output", "global", "mags_to_slcs.tsv")
-    
+    if opts.veba_major_version == 2:
+        genome_cluster_filepath = os.path.join(opts.veba_directory, "cluster", "output", "global", "mags_to_slcs.tsv")
+    elif opts.veba_major_version == 3:
+        genome_cluster_filepath = os.path.join(opts.veba_directory, "cluster", "output", "genomes_to_pangenomes.tsv.gz")
+
     if os.path.exists(genome_cluster_filepath):
         logger.info(f"Adding genome clusters from {genome_cluster_filepath}")
         with open_file_reader(genome_cluster_filepath) as f_in:

--- a/bin/leviathan-profile-pathway.py
+++ b/bin/leviathan-profile-pathway.py
@@ -33,6 +33,7 @@ from leviathan.index import(
 )
 
 from leviathan.profile_pathway import(
+    check_reads_format,
     run_salmon_quant,
     reformat_gene_abundance,
     reformat_feature_abundance,
@@ -62,8 +63,9 @@ def main(args=None):
 
     # Pipeline
     parser_io = parser.add_argument_group('I/O arguments')
-    parser_io.add_argument("-1","--forward_reads", type=str,  help = "path/to/forward_reads.fq[.gz] (Cannot be used with -s/--read_sketch)")
-    parser_io.add_argument("-2","--reverse_reads", type=str,  help = "path/to/reverse_reads.fq[.gz] (Cannot be used with -s/--read_sketch)")
+    parser_io.add_argument("-1","--forward_reads", type=str,  help = "path/to/forward_reads.fq[.gz] (Cannot be used with single_reads)")
+    parser_io.add_argument("-2","--reverse_reads", type=str,  help = "path/to/reverse_reads.fq[.gz] (Cannot be used with single_reads)")
+    parser_io.add_argument("-r","--single_reads", type=str,  help = "path/to/reads.fq[.gz] (Cannot be used with paired-end reads -1/-2)")
     # parser_io.add_argument("--ont", type=str,  help = "path/to/ont_reads.fq[.gz] (Cannot be used with -s/--read_sketch)")
     parser_io.add_argument("-n", "--name", type=str, required=True, help="Name of sample")
     parser_io.add_argument("-o","--project_directory", type=str, default="leviathan_output/profiling/pathway", help = "path/to/project_directory (e.g., leviathan_output/profiling/pathway]")
@@ -131,6 +133,14 @@ def main(args=None):
     # Config
     config = read_json(os.path.join(opts.index_directory, "config.json"))
 
+    # Determine input reads format
+    input_reads_format = check_reads_format(
+        forward_reads=opts.forward_reads, 
+        reverse_reads=opts.reverse_reads, 
+        single_reads=opts.single_reads,
+        logger=logger,
+        )
+
     # Check Salmon database
     logger.info("Checking Salmon index") 
     check_salmon_index(
@@ -196,8 +206,10 @@ def main(args=None):
         n_jobs=opts.n_jobs, 
         output_directory=os.path.join(output_directory, "intermediate"), 
         index_directory=opts.index_directory,
+        input_reads_format=input_reads_format,
         forward_reads=opts.forward_reads, 
         reverse_reads=opts.reverse_reads, 
+        single_reads=opts.single_reads,
         minimum_score_fraction=opts.minimum_score_fraction, 
         include_mappings=opts.salmon_include_mappings,
         alignment_format=opts.alignment_format,

--- a/bin/leviathan-profile-taxonomy.py
+++ b/bin/leviathan-profile-taxonomy.py
@@ -32,7 +32,8 @@ from pyexeggutor import (
 from leviathan.profile_taxonomy import(
     check_genome_database,
     check_reads_format,
-    run_sylph_reads_sketcher,
+    run_sylph_reads_sketcher_paired,
+    run_sylph_reads_sketcher_single,
     run_sylph_profiler,
 )
 
@@ -56,6 +57,7 @@ def main(args=None):
     parser_io = parser.add_argument_group('I/O arguments')
     parser_io.add_argument("-1","--forward_reads", type=str,  help = "path/to/forward_reads.fq[.gz] (Cannot be used with -s/--read_sketch)")
     parser_io.add_argument("-2","--reverse_reads", type=str,  help = "path/to/reverse_reads.fq[.gz] (Cannot be used with -s/--read_sketch)")
+    parser_io.add_argument("-r","--single_reads", type=str,  help = "path/to/reads.fq[.gz] (Cannot be used with -s/--read_sketch or -1/-2)")
     parser_io.add_argument("-s","--reads_sketch", type=str, help = "path/to/reads_sketch.sylsp (e.g., sylph sketch output) (Cannot be used with -1/--forward_reads and -2/--reverse_reads)")
     parser_io.add_argument("-n", "--name", type=str, required=True, help="Name of sample")
     parser_io.add_argument("-o","--project_directory", type=str, default="leviathan_output/profiling/taxonomy", help = "path/to/project_directory (e.g., leviathan_output/profiling/taxonomy]")
@@ -116,6 +118,7 @@ def main(args=None):
     input_reads_format = check_reads_format(
         forward_reads=opts.forward_reads, 
         reverse_reads=opts.reverse_reads, 
+        single_reads=opts.single_reads,
         reads_sketch=opts.reads_sketch,
         logger=logger,
         )
@@ -136,12 +139,12 @@ def main(args=None):
 
     if input_reads_format == "paired":
         # Process and check inputs
-        logger.info("Sketching reads")
+        logger.info("Sketching reads (paired)")
 
-        # ==========================
-        # Build Sylph reads sketcher
-        # ==========================
-        cmd_sylph_reads_sketcher = run_sylph_reads_sketcher(
+        # ===================================
+        # Build Sylph reads sketcher (paired)
+        # ===================================
+        cmd_sylph_reads_sketcher = run_sylph_reads_sketcher_paired(
                         logger=logger,
                         log_directory=os.path.join(output_directory, "logs"), 
                         sylph_executable=opts.sylph_executable, 
@@ -149,6 +152,28 @@ def main(args=None):
                         output_directory=os.path.join(output_directory, "intermediate"), 
                         forward_reads=opts.forward_reads, 
                         reverse_reads=opts.reverse_reads,
+                        k=opts.sylph_k, 
+                        minimum_spacing=opts.sylph_minimum_spacing, 
+                        subsampling_rate=opts.sylph_subsampling_rate, 
+                        sylph_sketch_options=opts.sylph_sketch_options, 
+
+        )
+        opts.reads_sketch = os.path.join(output_directory, "intermediate", "reads.sylsp")
+        logger.info(f"Setting --reads_sketch to {opts.reads_sketch}")
+    elif input_reads_format == "single":
+        # Process and check inputs
+        logger.info("Sketching reads (single)")
+
+        # ===================================
+        # Build Sylph reads sketcher (single)
+        # ===================================
+        cmd_sylph_reads_sketcher = run_sylph_reads_sketcher_single(
+                        logger=logger,
+                        log_directory=os.path.join(output_directory, "logs"), 
+                        sylph_executable=opts.sylph_executable, 
+                        n_jobs=opts.n_jobs, 
+                        output_directory=os.path.join(output_directory, "intermediate"), 
+                        single_reads=opts.single_reads, 
                         k=opts.sylph_k, 
                         minimum_spacing=opts.sylph_minimum_spacing, 
                         subsampling_rate=opts.sylph_subsampling_rate, 

--- a/bin/leviathan-profile-taxonomy.py
+++ b/bin/leviathan-profile-taxonomy.py
@@ -32,8 +32,7 @@ from pyexeggutor import (
 from leviathan.profile_taxonomy import(
     check_genome_database,
     check_reads_format,
-    run_sylph_reads_sketcher_paired,
-    run_sylph_reads_sketcher_single,
+    run_sylph_reads_sketcher,
     run_sylph_profiler,
 )
 
@@ -137,21 +136,23 @@ def main(args=None):
     os.makedirs(os.path.join(output_directory, "logs"), exist_ok=True)
     os.makedirs(os.path.join(output_directory, "tmp"), exist_ok=True)
 
-    if input_reads_format == "paired":
+    if input_reads_format in {"paired","single"}:
         # Process and check inputs
         logger.info("Sketching reads (paired)")
 
         # ===================================
-        # Build Sylph reads sketcher (paired)
+        # Build Sylph reads sketcher
         # ===================================
-        cmd_sylph_reads_sketcher = run_sylph_reads_sketcher_paired(
+        cmd_sylph_reads_sketcher = run_sylph_reads_sketcher(
                         logger=logger,
                         log_directory=os.path.join(output_directory, "logs"), 
                         sylph_executable=opts.sylph_executable, 
                         n_jobs=opts.n_jobs, 
                         output_directory=os.path.join(output_directory, "intermediate"), 
+                        input_reads_format=input_reads_format,
                         forward_reads=opts.forward_reads, 
                         reverse_reads=opts.reverse_reads,
+                        single_reads=opts.single_reads,
                         k=opts.sylph_k, 
                         minimum_spacing=opts.sylph_minimum_spacing, 
                         subsampling_rate=opts.sylph_subsampling_rate, 
@@ -160,33 +161,11 @@ def main(args=None):
         )
         opts.reads_sketch = os.path.join(output_directory, "intermediate", "reads.sylsp")
         logger.info(f"Setting --reads_sketch to {opts.reads_sketch}")
-    elif input_reads_format == "single":
-        # Process and check inputs
-        logger.info("Sketching reads (single)")
 
-        # ===================================
-        # Build Sylph reads sketcher (single)
-        # ===================================
-        cmd_sylph_reads_sketcher = run_sylph_reads_sketcher_single(
-                        logger=logger,
-                        log_directory=os.path.join(output_directory, "logs"), 
-                        sylph_executable=opts.sylph_executable, 
-                        n_jobs=opts.n_jobs, 
-                        output_directory=os.path.join(output_directory, "intermediate"), 
-                        single_reads=opts.single_reads, 
-                        k=opts.sylph_k, 
-                        minimum_spacing=opts.sylph_minimum_spacing, 
-                        subsampling_rate=opts.sylph_subsampling_rate, 
-                        sylph_sketch_options=opts.sylph_sketch_options, 
-
-        )
-        opts.reads_sketch = os.path.join(output_directory, "intermediate", "reads.sylsp")
-        logger.info(f"Setting --reads_sketch to {opts.reads_sketch}")
     else:
         logger.info(f"Skipping read sketching and using {opts.reads_sketch}")
         if opts.reads_sketch is None:
             raise ValueError("Please either provide -1/-2 paired reads or -s/--reads_sketch")
-
         
     # ====================
     # Build Sylph profiler

--- a/leviathan/__init__.py
+++ b/leviathan/__init__.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-__version__ = "2026.3.10"
+__version__ = "2026.3.11"
 from . import utils
 from . import index
 from . import profile_taxonomy

--- a/leviathan/__init__.py
+++ b/leviathan/__init__.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-__version__ = "2026.3.3"
+__version__ = "2026.3.10"
 from . import utils
 from . import index
 from . import profile_taxonomy

--- a/leviathan/profile_pathway.py
+++ b/leviathan/profile_pathway.py
@@ -32,7 +32,7 @@ def check_reads_format(forward_reads, reverse_reads, single_reads, reads_sketch,
         assert reverse_reads is not None, "If running in --input_reads_format paired mode, --forward_reads and --reverse_reads are needed."
         assert single_reads is None, "If running in --input_reads_format paired mode, you cannot provide -r/--single_reads"
         input_reads_format = "paired"
-    if reads_sketch is not None:
+    if single_reads is not None:
         assert forward_reads is None, "If running in --input_reads_format single mode, you cannot provide --forward_reads, --reverse_reads"
         assert reverse_reads is None, "If running in --input_reads_format single mode, you cannot provide --forward_reads, --reverse_reads"
         input_reads_format = "single"

--- a/leviathan/profile_pathway.py
+++ b/leviathan/profile_pathway.py
@@ -24,39 +24,89 @@ from pyexeggutor import (
 __program__ = os.path.split(sys.argv[0])[-1]
 
 
+def check_reads_format(forward_reads, reverse_reads, single_reads, reads_sketch, logger):
+    input_reads_format = None
+    if any([forward_reads, reverse_reads]):
+        assert forward_reads != reverse_reads, f"You probably mislabeled the input files because `forward_reads` should not be the same as `reverse_reads`: {forward_reads}"
+        assert forward_reads is not None, "If running in --input_reads_format paired mode, --forward_reads and --reverse_reads are needed."
+        assert reverse_reads is not None, "If running in --input_reads_format paired mode, --forward_reads and --reverse_reads are needed."
+        assert single_reads is None, "If running in --input_reads_format paired mode, you cannot provide -r/--single_reads"
+        input_reads_format = "paired"
+    if reads_sketch is not None:
+        assert forward_reads is None, "If running in --input_reads_format single mode, you cannot provide --forward_reads, --reverse_reads"
+        assert reverse_reads is None, "If running in --input_reads_format single mode, you cannot provide --forward_reads, --reverse_reads"
+        input_reads_format = "single"
+    if input_reads_format is None:
+        msg = "Could not determine input reads format.  Please provide either paired or single-end fastq."
+        logger.critical(msg)
+        raise ValueError(msg)
+    logger.info(f"Auto-detecting reads format: {input_reads_format}")
+    return input_reads_format
+
 # Run Salmon quant (salmon quant --meta --libType A --index ${INDEX} -1 ${R1} -2 ${R2} --threads ${N_JOBS}  --minScoreFraction=0.87 --writeUnmappedNames)
-def run_salmon_quant(logger, log_directory, salmon_executable, samtools_executable, n_jobs, output_directory, index_directory, forward_reads, reverse_reads, minimum_score_fraction, include_mappings, alignment_format, salmon_gzip, salmon_quant_options):
+def run_salmon_quant(logger, log_directory, salmon_executable, samtools_executable, n_jobs, output_directory, index_directory, input_reads_format, forward_reads, reverse_reads, single_reads, minimum_score_fraction, include_mappings, alignment_format, salmon_gzip, salmon_quant_options):
     arguments = dict(
-        command=[
-            salmon_executable,
-            "quant",
-            "--meta",
-            "--libType",
-            "A",
-            "--threads",
-            n_jobs,
-            "--minScoreFraction",
-            minimum_score_fraction,
-            "--index",
-            os.path.join(index_directory, "salmon_index"),
-            "-1",
-            forward_reads,
-            "-2",
-            reverse_reads,
-            "--writeUnmappedNames",
-            salmon_quant_options if salmon_quant_options else "", 
-            "--output",
-            output_directory,
-        ],
+
         name="salmon_quant",
-        validate_input_filepaths=[
-            forward_reads,
-            reverse_reads,
-        ],
+
         validate_output_filepaths=[
             os.path.join(output_directory, "quant.sf.gz") if salmon_gzip else os.path.join(output_directory, "quant.sf"),
         ],
     )
+    if input_reads_format == "paired":
+        arguments["command"] =[
+                salmon_executable,
+                "quant",
+                "--meta",
+                "--libType",
+                "A",
+                "--threads",
+                n_jobs,
+                "--minScoreFraction",
+                minimum_score_fraction,
+                "--index",
+                os.path.join(index_directory, "salmon_index"),
+                "-1",
+                forward_reads,
+                "-2",
+                reverse_reads,
+                "--writeUnmappedNames",
+                salmon_quant_options if salmon_quant_options else "", 
+                "--output",
+                output_directory,
+            ]
+        arguments["validate_input_filepaths"] = [
+                forward_reads,
+                reverse_reads,
+            ]
+    elif input_reads_format == "single":
+        arguments["command"] =[
+                salmon_executable,
+                "quant",
+                "--meta",
+                "--libType",
+                "A",
+                "--threads",
+                n_jobs,
+                "--minScoreFraction",
+                minimum_score_fraction,
+                "--index",
+                os.path.join(index_directory, "salmon_index"),
+                "-u",
+                single_reads,
+                "--writeUnmappedNames",
+                salmon_quant_options if salmon_quant_options else "", 
+                "--output",
+                output_directory,
+            ]
+        arguments["validate_input_filepaths"] = [
+                single_reads,
+            ]
+    else:
+        logger.critical("Could not determine input reads format")
+        sys.exit(1)
+
+    
     if include_mappings:
         if alignment_format == "sam":
             arguments["command"] += [
@@ -97,6 +147,7 @@ def run_salmon_quant(logger, log_directory, salmon_executable, samtools_executab
                 "-",
             ]
             arguments["validate_output_filepaths"].append(os.path.join(output_directory, "mapped.sorted.bam"))
+
             
     # Remove unmapped reads
     arguments["command"] += [

--- a/leviathan/profile_pathway.py
+++ b/leviathan/profile_pathway.py
@@ -24,7 +24,7 @@ from pyexeggutor import (
 __program__ = os.path.split(sys.argv[0])[-1]
 
 
-def check_reads_format(forward_reads, reverse_reads, single_reads, reads_sketch, logger):
+def check_reads_format(forward_reads, reverse_reads, single_reads, logger):
     input_reads_format = None
     if any([forward_reads, reverse_reads]):
         assert forward_reads != reverse_reads, f"You probably mislabeled the input files because `forward_reads` should not be the same as `reverse_reads`: {forward_reads}"

--- a/leviathan/profile_pathway.py
+++ b/leviathan/profile_pathway.py
@@ -92,7 +92,7 @@ def run_salmon_quant(logger, log_directory, salmon_executable, samtools_executab
                 minimum_score_fraction,
                 "--index",
                 os.path.join(index_directory, "salmon_index"),
-                "-u",
+                "-r",
                 single_reads,
                 "--writeUnmappedNames",
                 salmon_quant_options if salmon_quant_options else "", 

--- a/leviathan/profile_taxonomy.py
+++ b/leviathan/profile_taxonomy.py
@@ -19,16 +19,24 @@ from pyexeggutor import (
 )
 
     
-def check_reads_format(forward_reads, reverse_reads, reads_sketch, logger):
+def check_reads_format(forward_reads, reverse_reads, single_reads, reads_sketch, logger):
     input_reads_format = None
     if any([forward_reads, reverse_reads]):
         assert forward_reads != reverse_reads, f"You probably mislabeled the input files because `forward_reads` should not be the same as `reverse_reads`: {forward_reads}"
         assert forward_reads is not None, "If running in --input_reads_format paired mode, --forward_reads and --reverse_reads are needed."
         assert reverse_reads is not None, "If running in --input_reads_format paired mode, --forward_reads and --reverse_reads are needed."
+        assert single_reads is None, "If running in --input_reads_format paired mode, you cannot provide -r/--single_reads"
+        assert reads_sketch is None, "If running in --input_reads_format paired mode, you cannot provide -s/--reads_sketch"
         input_reads_format = "paired"
+    if reads_sketch is not None:
+        assert forward_reads is None, "If running in --input_reads_format single mode, you cannot provide --forward_reads, --reverse_reads"
+        assert reverse_reads is None, "If running in --input_reads_format single mode, you cannot provide --forward_reads, --reverse_reads"
+        assert reads_sketch is None, "If running in --input_reads_format single mode, you cannot provide -s/--reads_sketch"
+        input_reads_format = "single"
     if reads_sketch is not None:
         assert forward_reads is None, "If running in --input_reads_format sketch mode, you cannot provide --forward_reads, --reverse_reads"
         assert reverse_reads is None, "If running in --input_reads_format sketch mode, you cannot provide --forward_reads, --reverse_reads"
+        assert single_reads is None, "If running in --input_reads_format sketch mode, you cannot provide -r/--single_reads"
         input_reads_format = "sketch"
     if input_reads_format is None:
         msg = "Could not determine input reads format.  Please provide either paired fastq or a Sylph sketch."
@@ -60,7 +68,7 @@ def check_genome_database(index_directory, logger):
     
         
 # Run Sylph reads sketcher
-def run_sylph_reads_sketcher(logger, log_directory, sylph_executable, n_jobs, output_directory, forward_reads, reverse_reads, k, minimum_spacing, subsampling_rate, sylph_sketch_options):
+def run_sylph_reads_sketcher_paired(logger, log_directory, sylph_executable, n_jobs, output_directory, forward_reads, reverse_reads, k, minimum_spacing, subsampling_rate, sylph_sketch_options):
     forward_reads_filename = os.path.split(forward_reads)[-1]
     cmd = RunShellCommand(
         command=[
@@ -92,8 +100,54 @@ def run_sylph_reads_sketcher(logger, log_directory, sylph_executable, n_jobs, ou
             reverse_reads,
         ],
         validate_output_filepaths=[
-            forward_reads,
-            reverse_reads,
+            os.path.join(output_directory, "reads.sylsp"),
+        ],
+    )
+    
+    # Run
+    logger.info(f"[{cmd.name}] running command: {cmd.command}")
+    cmd.run()
+    logger.info(f"[{cmd.name}] duration: {cmd.duration_}")
+    logger.info(f"[{cmd.name}] peak memory: {format_bytes(cmd.peak_memory_)}")
+
+    # Dump
+    logger.info(f"[{cmd.name}] dumping stdout, stderr, and return code: {log_directory}")
+    cmd.dump(log_directory)
+    
+    # Validate
+    logger.info(f"[{cmd.name}] checking return code status: {cmd.returncode_}")
+    cmd.check_status()
+    return cmd
+
+def run_sylph_reads_sketcher_single(logger, log_directory, sylph_executable, n_jobs, output_directory, single_reads, k, minimum_spacing, subsampling_rate, sylph_sketch_options):
+    reads_filename = os.path.split(single_reads)[-1]
+    cmd = RunShellCommand(
+        command=[
+            sylph_executable,
+            "sketch",
+            "-t",
+            n_jobs,
+            "-k",
+            k,
+            "-c",
+            subsampling_rate,
+            "--min-spacing",
+            minimum_spacing,
+            "-d",
+            output_directory,
+            "-r",
+            single_reads,
+            "&&",
+            "mv",
+            os.path.join(output_directory, f"{reads_filename}.sylsp"),
+            os.path.join(output_directory, "reads.sylsp"),
+            
+        ],
+        name="sylph_reads_sketcher",
+        validate_input_filepaths=[
+            single_reads,
+        ],
+        validate_output_filepaths=[
             os.path.join(output_directory, "reads.sylsp"),
         ],
     )

--- a/leviathan/profile_taxonomy.py
+++ b/leviathan/profile_taxonomy.py
@@ -18,7 +18,6 @@ from pyexeggutor import (
     check_argument_choice,
 )
 
-    
 def check_reads_format(forward_reads, reverse_reads, single_reads, reads_sketch, logger):
     input_reads_format = None
     if any([forward_reads, reverse_reads]):
@@ -68,40 +67,77 @@ def check_genome_database(index_directory, logger):
     
         
 # Run Sylph reads sketcher
-def run_sylph_reads_sketcher_paired(logger, log_directory, sylph_executable, n_jobs, output_directory, forward_reads, reverse_reads, k, minimum_spacing, subsampling_rate, sylph_sketch_options):
-    forward_reads_filename = os.path.split(forward_reads)[-1]
-    cmd = RunShellCommand(
-        command=[
-            sylph_executable,
-            "sketch",
-            "-t",
-            n_jobs,
-            "-k",
-            k,
-            "-c",
-            subsampling_rate,
-            "--min-spacing",
-            minimum_spacing,
-            "-d",
-            output_directory,
-            "-1",
-            forward_reads,
-            "-2",
-            reverse_reads,
-            "&&",
-            "mv",
-            os.path.join(output_directory, f"{forward_reads_filename}.paired.sylsp"),
-            os.path.join(output_directory, "reads.sylsp"),
-            
-        ],
+def run_sylph_reads_sketcher(logger, log_directory, sylph_executable, n_jobs, output_directory, input_reads_format, forward_reads, reverse_reads, single_reads, k, minimum_spacing, subsampling_rate, sylph_sketch_options):
+
+    arguments = dict(
         name="sylph_reads_sketcher",
-        validate_input_filepaths=[
-            forward_reads,
-            reverse_reads,
-        ],
         validate_output_filepaths=[
             os.path.join(output_directory, "reads.sylsp"),
         ],
+    )
+
+    if input_reads_format == "paired":
+        forward_reads_filename = os.path.split(forward_reads)[-1]
+
+        arguments["command"] = [
+                sylph_executable,
+                "sketch",
+                "-t",
+                n_jobs,
+                "-k",
+                k,
+                "-c",
+                subsampling_rate,
+                "--min-spacing",
+                minimum_spacing,
+                "-d",
+                output_directory,
+                "-1",
+                forward_reads,
+                "-2",
+                reverse_reads,
+                "&&",
+                "mv",
+                os.path.join(output_directory, f"{forward_reads_filename}.paired.sylsp"),
+                os.path.join(output_directory, "reads.sylsp"), 
+            ]
+        arguments["validate_input_filepaths"] = [
+            forward_reads,
+            reverse_reads,
+        ]
+
+    elif input_reads_format == "single":
+        singe_reads_filename = os.path.split(single_reads)[-1]
+
+        arguments["command"] = [
+                sylph_executable,
+                "sketch",
+                "-t",
+                n_jobs,
+                "-k",
+                k,
+                "-c",
+                subsampling_rate,
+                "--min-spacing",
+                minimum_spacing,
+                "-d",
+                output_directory,
+                "-r",
+                single_reads,
+                "&&",
+                "mv",
+                os.path.join(output_directory, f"{singe_reads_filename}.sylsp"),
+                os.path.join(output_directory, "reads.sylsp"), 
+            ]
+        arguments["validate_input_filepaths"] = [
+            single_reads
+        ]
+    else:
+        logger.critical("Could not determine input reads format")
+        sys.exit(1)
+
+    cmd = RunShellCommand(
+        **arguments,
     )
     
     # Run
@@ -119,53 +155,7 @@ def run_sylph_reads_sketcher_paired(logger, log_directory, sylph_executable, n_j
     cmd.check_status()
     return cmd
 
-def run_sylph_reads_sketcher_single(logger, log_directory, sylph_executable, n_jobs, output_directory, single_reads, k, minimum_spacing, subsampling_rate, sylph_sketch_options):
-    reads_filename = os.path.split(single_reads)[-1]
-    cmd = RunShellCommand(
-        command=[
-            sylph_executable,
-            "sketch",
-            "-t",
-            n_jobs,
-            "-k",
-            k,
-            "-c",
-            subsampling_rate,
-            "--min-spacing",
-            minimum_spacing,
-            "-d",
-            output_directory,
-            "-r",
-            single_reads,
-            "&&",
-            "mv",
-            os.path.join(output_directory, f"{reads_filename}.sylsp"),
-            os.path.join(output_directory, "reads.sylsp"),
-            
-        ],
-        name="sylph_reads_sketcher",
-        validate_input_filepaths=[
-            single_reads,
-        ],
-        validate_output_filepaths=[
-            os.path.join(output_directory, "reads.sylsp"),
-        ],
-    )
-    
-    # Run
-    logger.info(f"[{cmd.name}] running command: {cmd.command}")
-    cmd.run()
-    logger.info(f"[{cmd.name}] duration: {cmd.duration_}")
-    logger.info(f"[{cmd.name}] peak memory: {format_bytes(cmd.peak_memory_)}")
 
-    # Dump
-    logger.info(f"[{cmd.name}] dumping stdout, stderr, and return code: {log_directory}")
-    cmd.dump(log_directory)
-    
-    # Validate
-    logger.info(f"[{cmd.name}] checking return code status: {cmd.returncode_}")
-    cmd.check_status()
-    return cmd
 
 # Run Sylph profile
 def run_sylph_profiler(logger, log_directory, sylph_executable, n_jobs, output_directory, index_directory,  reads, minimum_ani, minimum_number_kmers, minimum_count_correct, sylph_profile_options):

--- a/leviathan/profile_taxonomy.py
+++ b/leviathan/profile_taxonomy.py
@@ -27,7 +27,7 @@ def check_reads_format(forward_reads, reverse_reads, single_reads, reads_sketch,
         assert single_reads is None, "If running in --input_reads_format paired mode, you cannot provide -r/--single_reads"
         assert reads_sketch is None, "If running in --input_reads_format paired mode, you cannot provide -s/--reads_sketch"
         input_reads_format = "paired"
-    if reads_sketch is not None:
+    if single_reads is not None:
         assert forward_reads is None, "If running in --input_reads_format single mode, you cannot provide --forward_reads, --reverse_reads"
         assert reverse_reads is None, "If running in --input_reads_format single mode, you cannot provide --forward_reads, --reverse_reads"
         assert reads_sketch is None, "If running in --input_reads_format single mode, you cannot provide -s/--reads_sketch"

--- a/test/commands/commands.leviathan-manifest.sh
+++ b/test/commands/commands.leviathan-manifest.sh
@@ -5,6 +5,6 @@ job_name="leviathan-manifest"
 working_directory="../working/${manifest_type}"
 reference_directory="${working_directory}/references"
 veba_directory="../../Analysis/veba_output/"
-manifest="${reference_directory}/manifest.${manifest_type}.tsv.gz"
+manifest="manifest.${manifest_type}.tsv.gz"
 compile-manifest-from-veba.py -i ${veba_directory} -t prokaryotic,eukaryotic -o ${manifest}
 

--- a/test/commands/commands.leviathan-manifest.sh
+++ b/test/commands/commands.leviathan-manifest.sh
@@ -6,5 +6,5 @@ working_directory="../working/${manifest_type}"
 reference_directory="${working_directory}/references"
 veba_directory="../../Analysis/veba_output/"
 manifest="manifest.${manifest_type}.tsv.gz"
-compile-manifest-from-veba.py -i ${veba_directory} -t prokaryotic,eukaryotic -o ${manifest}
+compile-manifest-from-veba.py -i ${veba_directory} -t prokaryotic,eukaryotic -o ${manifest} --veba_major_version 2
 


### PR DESCRIPTION
* [2026.3.11] - Added support for `-r/--single_reads` in both `profile-taxonomy.py` and `profile-pathway.py`. However, the `profile-pathway.py` needs `oarfish` to use long reads. [issue/#24](https://github.com/jolespin/leviathan/issues/24)