### PR TITLE
Refactor/add parallelization from kpp and deterministic flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 #### Daily Change Log:
+* [2026.7.16] - Added parallelization support for pathway coverage using `profile_pathway_coverage` from `kegg_pathway_profiler>=2026.7.16` in `leviathan-profile-pathway.py`. The `--n_jobs` flag now applies to both `salmon quant` and pathway coverage computation.
+* [2026.7.16] - Added `--deterministic` flag to `leviathan-profile-pathway.py` which passes `--deterministic` to `salmon quant` for byte-identical results across runs and thread counts.
 * [2026.7.8] - Added `--update_salmon_index` to `leviathan-index.py` and remove `-u` alias on `--update_with_genomes`
 * [2026.7.8] - **BREAKING CHANGE:** `Salmon` is reimplemented with `Rust` from `C++` so any `Leviathan` databases using `Salmon 1.x` will need to be updated.  `Leviathan` now requires `Salmon ≥ 2.x`.
 * [2026.3.11] - Added support for `-r/--single_reads` in both `profile-taxonomy.py` and `profile-pathway.py`. However, the `profile-pathway.py` needs `oarfish` to use long reads but there are no synthetic long-read metatranscriptomics to benchmark. [issue/#24](https://github.com/jolespin/leviathan/issues/24)

--- a/bin/leviathan-profile-pathway.py
+++ b/bin/leviathan-profile-pathway.py
@@ -32,6 +32,8 @@ from leviathan.index import(
     check_salmon_index,
 )
 
+from kegg_pathway_profiler.pathways import profile_pathway_coverage
+
 from leviathan.profile_pathway import(
     check_reads_format,
     run_salmon_quant,
@@ -40,7 +42,6 @@ from leviathan.profile_pathway import(
     build_wide_feature_prevalence_matrix,
     build_feature_prevalence_dictionary,
     build_feature_pathway_dictionary,
-    calculate_pathway_coverage,
     aggregate_pathway_abundance_and_append_coverage,
     aggregate_feature_abundance_for_clusters,
 )
@@ -83,6 +84,7 @@ def main(args=None):
     parser_salmon_quant.add_argument("--salmon_include_mappings", action="store_true", help="salmon quant| Include mappings")
     parser_salmon_quant.add_argument("--salmon_gzip", action="store_true", help="salmon quant | Gzip quant.sf")
 
+    parser_salmon_quant.add_argument("--deterministic", action="store_true", help="salmon quant | Deterministic quantification: byte-identical results across runs and thread counts [Default: False]")
     parser_salmon_quant.add_argument("--salmon_quant_options", type=str, default="", help="salmon quant| More options (e.g. --arg=1 ) https://salmon.readthedocs.io/en/latest/ [Default: '']")
 
     # Samtools
@@ -214,7 +216,8 @@ def main(args=None):
         include_mappings=opts.salmon_include_mappings,
         alignment_format=opts.alignment_format,
         salmon_gzip=opts.salmon_gzip,
-        salmon_quant_options=opts.salmon_quant_options, 
+        salmon_quant_options=opts.salmon_quant_options,
+        deterministic=opts.deterministic,
     )
        
     # ===============================
@@ -277,8 +280,13 @@ def main(args=None):
         logger.info(f"[level={level}] Building feature to pathways dictionary")
         feature_to_pathways = build_feature_pathway_dictionary(pathway_to_data)
         logger.info(f"[level={level}] Calculating pathway coverage")
-        coverages, step_coverages = calculate_pathway_coverage(genome_to_features, pathway_to_data)
-        
+        coverages, step_coverages, _ = profile_pathway_coverage(
+            genome_to_kos=genome_to_features,
+            database=pathway_to_data,
+            n_jobs=opts.n_jobs,
+            serialize_output=False,
+        )
+
         # Pathway abundances
         pathway_abundances_filepath = os.path.join(output_directory, "output", f"pathway_abundances.{level}s.{opts.output_format}")
         if opts.output_format != "parquet":
@@ -354,7 +362,12 @@ def main(args=None):
             logger.info(f"[level={level}] Building feature to pathways dictionary")
             feature_to_pathways = build_feature_pathway_dictionary(pathway_to_data)
             logger.info(f"[level={level}] Calculating pathway coverage")
-            coverages, step_coverages = calculate_pathway_coverage(genome_to_features, pathway_to_data)
+            coverages, step_coverages, _ = profile_pathway_coverage(
+                genome_to_kos=genome_to_features,
+                database=pathway_to_data,
+                n_jobs=opts.n_jobs,
+                serialize_output=False,
+            )
             
             # Pathway abundances
             pathway_abundances_filepath = os.path.join(output_directory, "output", f"pathway_abundances.{level}s.{opts.output_format}")

--- a/leviathan/__init__.py
+++ b/leviathan/__init__.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-__version__ = "2026.7.10"
+__version__ = "2026.7.16"
 from . import utils
 from . import index
 from . import profile_taxonomy

--- a/leviathan/profile_pathway.py
+++ b/leviathan/profile_pathway.py
@@ -10,7 +10,7 @@ import xarray as xr
 # from memory_profiler import profile
 
 from kegg_pathway_profiler.pathways import (
-    pathway_coverage_wrapper,
+    profile_pathway_coverage,
 )
 
 from pyexeggutor import (
@@ -44,7 +44,7 @@ def check_reads_format(forward_reads, reverse_reads, single_reads, logger):
     return input_reads_format
 
 # Run Salmon quant (salmon quant --meta --libType A --index ${INDEX} -1 ${R1} -2 ${R2} --threads ${N_JOBS}  --minScoreFraction=0.87 --writeUnmappedNames)
-def run_salmon_quant(logger, log_directory, salmon_executable, samtools_executable, n_jobs, output_directory, index_directory, input_reads_format, forward_reads, reverse_reads, single_reads, minimum_score_fraction, include_mappings, alignment_format, salmon_gzip, salmon_quant_options):
+def run_salmon_quant(logger, log_directory, salmon_executable, samtools_executable, n_jobs, output_directory, index_directory, input_reads_format, forward_reads, reverse_reads, single_reads, minimum_score_fraction, include_mappings, alignment_format, salmon_gzip, salmon_quant_options, deterministic=False):
     arguments = dict(
 
         name="salmon_quant",
@@ -71,7 +71,8 @@ def run_salmon_quant(logger, log_directory, salmon_executable, samtools_executab
                 "-2",
                 reverse_reads,
                 "--writeUnmappedNames",
-                salmon_quant_options if salmon_quant_options else "", 
+                "--deterministic" if deterministic else "",
+                salmon_quant_options if salmon_quant_options else "",
                 "--output",
                 output_directory,
             ]
@@ -95,7 +96,8 @@ def run_salmon_quant(logger, log_directory, salmon_executable, samtools_executab
                 "-r",
                 single_reads,
                 "--writeUnmappedNames",
-                salmon_quant_options if salmon_quant_options else "", 
+                "--deterministic" if deterministic else "",
+                salmon_quant_options if salmon_quant_options else "",
                 "--output",
                 output_directory,
             ]
@@ -300,27 +302,6 @@ def build_feature_pathway_dictionary(pathway_to_data:dict):
     return feature_to_pathways
             
         
-def calculate_pathway_coverage(genome_to_features:dict, pathway_to_data:dict):
-    # Coverage
-    coverages = dict()
-    step_coverages = defaultdict(dict)
-    # Calculate pathway coverage for all genomes
-    for id_genome, evaluation_features in genome_to_features.items():
-        # Calculate pathway coverage for all pathways based on evaluation feature set
-        pathway_to_results = pathway_coverage_wrapper(
-            evaluation_kos=evaluation_features,
-            database=pathway_to_data,
-            progressbar_description=f"Calculating pathway coverage: {id_genome}",
-        )
-
-        # Coverage
-        for id_pathway, results in pathway_to_results.items():
-            coverages[(id_genome, id_pathway)] = results["coverage"]
-            # Collect step coverage data
-            for step, value in results["step_coverage"].items():
-                step_label = f"{step[0]}-{step[1]}"
-                step_coverages[id_genome][(id_pathway, step_label)] = value
-    return coverages, step_coverages
 
 def aggregate_pathway_abundance_and_append_coverage(df_feature_abundance:pd.DataFrame, feature_to_pathways:dict, coverages:dict, index_names = ["id_genome", "id_pathway"]):
     abundance_matrix = defaultdict(lambda: np.zeros(3, dtype=float))

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ pandas
 pyfastx
 networkx
 scipy
-kegg_pathway_profiler>=2026.5.26
+kegg_pathway_profiler>=2026.7.16
 pyexeggutor>=2025.11.7
 pyarrow
 xarray


### PR DESCRIPTION
* [2026.7.16] - Added parallelization support for pathway coverage using `profile_pathway_coverage` from `kegg_pathway_profiler>=2026.7.16` in `leviathan-profile-pathway.py`. The `--n_jobs` flag now applies to both `salmon quant` and pathway coverage computation.
* [2026.7.16] - Added `--deterministic` flag to `leviathan-profile-pathway.py` which passes `--deterministic` to `salmon quant` for byte-identical results across runs and thread counts.